### PR TITLE
Bug fixes and enhancements. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ Before install TortoiseFuzz, user should prepare llvm.
     ```
 - Compile clang. `-DLLVM_ENABLE_ASSERTIONS=On` is required, otherwise the TortoiseFuzz maybe won't work properly.
     ```
-    $ mkdir build
+    $ mkdir build & cd build
     $ cmake -G "Unix Makefiles" -DLLVM_ENABLE_ASSERTIONS=On -DCMAKE_BUILD_TYPE=Release ../llvm
     $ make -j4
     $ make install
+    ```
+- Add the built clang 6.0.0 to your PATH environment.
+    ```
+    $ export PATH=path_to_clang/build/bin/:$PATH
     ```
 
 # Install TortoiseFuzz

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 #  About TortoiseFuzz
 
 <img align="left" src="logo.jpg" width=100>
+
 We propose coverage accounting, an innovative approach that evaluates code coverage by security impacts. Based on the proposed metrics, we design a new scheme to prioritize fuzzing inputs and develop TortoiseFuzz, a greybox fuzzer for memory corruption vulnerabilities. 
 Read the [NDSS 2020 paper (Not all coverage measurements are equal: fuzzing by coverage accounting for input prioritization)](https://www.ndss-symposium.org/ndss-paper/not-all-coverage-measurements-are-equal-fuzzing-by-coverage-accounting-for-input-prioritization/) for more details. TortoiseFuzz is developed based on top of Michal Zalewski's  (lcamtuf@google.com) AFL.
 
@@ -27,7 +28,7 @@ Before install TortoiseFuzz, user should prepare llvm.
     $ make -j4
     $ make install
     ```
-- Add the built clang 6.0.0 to your PATH environment.
+- Add the built clang 6.0.0 to your PATH environment variable.
     ```
     $ export PATH=path_to_clang/build/bin/:$PATH
     ```

--- a/bb_metric/afl-fuzz.c
+++ b/bb_metric/afl-fuzz.c
@@ -4818,7 +4818,7 @@ static u8 trim_case(char** argv, struct queue_entry* q, u8* in_buf) {
           needs_write = 1;
           memcpy(clean_trace, trace_bits, MAP_SIZE);
           memcpy(clean_memwrite, memwrite_bits, MAP_SIZE*sizeof(u32));
-          memcpy(clean_memread, memwrite_bits, MAP_SIZE*sizeof(u32));
+          memcpy(clean_memread, memread_bits, MAP_SIZE*sizeof(u32));
 
         }
 


### PR DESCRIPTION
This PR contains several (minor) fixes or enhancements.
1. The `memcpy(clean_memread, memwrite_bits, MAP_SIZE*sizeof(u32));` in  line 4821 of `bb_metrics/afl-fuzz.c` should be `memcpy(clean_memread, memread_bits, MAP_SIZE*sizeof(u32));` instead.
2. Enhance the README with instructions to use the built clang to compile TortoiseFuzz. 
3. The paper link preview was broken on GitHub Markdown rendering. Added a line to fix it.